### PR TITLE
Issue-204: Increase DTR reset to 100ms

### DIFF
--- a/serial/serial.go
+++ b/serial/serial.go
@@ -280,14 +280,13 @@ func (sp *SerialPort) Flush() error {
 	return nil
 }
 
-var defaultDTRPause = 10 * time.Millisecond
+var defaultDTRPause = 100 * time.Millisecond
 
 func (sp *SerialPort) setDTR() error {
 	err := sp.ioctl(unix.TIOCMBIS, unix.TIOCM_DTR)
 	if err != nil {
 		return fmt.Errorf("[ToggleDTR] DTR set error: %d", err)
 	}
-	time.Sleep(defaultDTRPause)
 	return nil
 }
 
@@ -296,7 +295,6 @@ func (sp *SerialPort) clearDTR() error {
 	if err != nil {
 		return fmt.Errorf("[ToggleDTR] DTR clear error: %d", err)
 	}
-	time.Sleep(defaultDTRPause)
 	return nil
 }
 
@@ -307,6 +305,8 @@ func (sp *SerialPort) ResetViaDTR() error {
 	if err != nil {
 		return err
 	}
+
+	time.Sleep(defaultDTRPause)
 
 	err = sp.setDTR()
 	if err != nil {


### PR DESCRIPTION
This may well fix the issue we have been looking at. The Reset on the DTR pin does not always re-power the dongle. So I have increased the timeout between clearing and setting.